### PR TITLE
fix: accept/reject tracked changes in tables (closes #9)

### DIFF
--- a/docx_revisions/document.py
+++ b/docx_revisions/document.py
@@ -8,10 +8,11 @@ for accepting, rejecting, and performing find-and-replace with tracking.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import IO, List
+from typing import IO, Iterator, List
 
 from docx import Document as _new_document
 from docx.document import Document as _DocumentClass
+from docx.table import Table as _Table
 
 from docx_revisions.paragraph import RevisionParagraph
 from docx_revisions.revision import TrackedChange
@@ -54,14 +55,55 @@ class RevisionDocument:
 
     @property
     def paragraphs(self) -> List[RevisionParagraph]:
-        """All body paragraphs as ``RevisionParagraph`` objects."""
+        """All body paragraphs as ``RevisionParagraph`` objects.
+
+        Only paragraphs in the document body are returned. Paragraphs inside
+        tables are excluded. Use :attr:`all_paragraphs` to iterate over every
+        paragraph including those nested in tables.
+        """
         return [RevisionParagraph.from_paragraph(p) for p in self._document.paragraphs]
 
     @property
+    def all_paragraphs(self) -> List[RevisionParagraph]:
+        """Every paragraph in the document, including those inside tables.
+
+        Walks the document body and recurses into all tables (including
+        nested tables within cells).
+
+        Example:
+            ```python
+            rdoc = RevisionDocument("contract.docx")
+            for para in rdoc.all_paragraphs:
+                if para.has_track_changes:
+                    print(para.accepted_text)
+            ```
+        """
+        return list(self._iter_all_paragraphs())
+
+    def _iter_all_paragraphs(self) -> Iterator[RevisionParagraph]:
+        """Yield every ``RevisionParagraph`` in the body and all tables.
+
+        Recurses into nested tables via ``cell.tables``.
+        """
+        for p in self._document.paragraphs:
+            yield RevisionParagraph.from_paragraph(p)
+        for table in self._document.tables:
+            yield from self._iter_table_paragraphs(table)
+
+    def _iter_table_paragraphs(self, table: _Table) -> Iterator[RevisionParagraph]:
+        """Yield every ``RevisionParagraph`` inside *table* recursively."""
+        for row in table.rows:
+            for cell in row.cells:
+                for p in cell.paragraphs:
+                    yield RevisionParagraph.from_paragraph(p)
+                for nested in cell.tables:
+                    yield from self._iter_table_paragraphs(nested)
+
+    @property
     def track_changes(self) -> List[TrackedChange]:
-        """All tracked changes across the entire document body."""
+        """All tracked changes across the document body and tables."""
         changes: List[TrackedChange] = []
-        for para in self.paragraphs:
+        for para in self._iter_all_paragraphs():
             changes.extend(para.track_changes)
         return changes
 
@@ -69,8 +111,9 @@ class RevisionDocument:
         """Accept every tracked change in the document.
 
         Insertions are kept (wrapper removed), deletions are removed entirely.
+        Tracked changes inside tables (including nested tables) are processed.
         """
-        for para in self.paragraphs:
+        for para in self._iter_all_paragraphs():
             for change in list(para.track_changes):
                 change.accept()
 
@@ -78,9 +121,10 @@ class RevisionDocument:
         """Reject every tracked change in the document.
 
         Insertions are removed entirely, deletions are kept (wrapper removed,
-        ``w:delText`` converted back to ``w:t``).
+        ``w:delText`` converted back to ``w:t``). Tracked changes inside
+        tables (including nested tables) are processed.
         """
-        for para in self.paragraphs:
+        for para in self._iter_all_paragraphs():
             for change in list(para.track_changes):
                 change.reject()
 
@@ -89,7 +133,8 @@ class RevisionDocument:
     ) -> int:
         """Find and replace across the whole document with track changes.
 
-        Searches all paragraphs in the document body and tables.
+        Searches all paragraphs in the document body and tables (including
+        nested tables).
 
         Args:
             search_text: Text to find.
@@ -112,17 +157,8 @@ class RevisionDocument:
             ```
         """
         total_count = 0
-
-        for para in self.paragraphs:
+        for para in self._iter_all_paragraphs():
             total_count += para.replace_tracked(search_text, replace_text, author=author, comment=comment)
-
-        for table in self._document.tables:
-            for row in table.rows:
-                for cell in row.cells:
-                    for p in cell.paragraphs:
-                        rp = RevisionParagraph.from_paragraph(p)
-                        total_count += rp.replace_tracked(search_text, replace_text, author=author, comment=comment)
-
         return total_count
 
     def save(self, path: str | Path) -> None:

--- a/tests/test_accept_reject.py
+++ b/tests/test_accept_reject.py
@@ -130,7 +130,7 @@ def _build_doc_with_table_changes():
 
 
 class DescribeTables:
-    """Accept/reject tracked changes inside tables (issue #9)."""
+    """Accept/reject tracked changes inside tables."""
 
     def it_sees_tracked_changes_inside_tables(self):
         doc = _build_doc_with_table_changes()

--- a/tests/test_accept_reject.py
+++ b/tests/test_accept_reject.py
@@ -101,3 +101,115 @@ class DescribeAcceptReject_from_docx:
         rdoc.accept_all()
 
         assert len(rdoc.track_changes) == 0
+
+
+def _build_doc_with_table_changes():
+    """Build a Document with tracked changes in body, a table cell, and a nested table."""
+    doc = Document()
+
+    body_p = doc.add_paragraph("Body ")
+    RevisionParagraph.from_paragraph(body_p).add_tracked_insertion(text="body_ins", author="A", revision_id=1)
+
+    table = doc.add_table(rows=1, cols=2)
+
+    cell_p = table.cell(0, 0).paragraphs[0]
+    cell_p.add_run("Cell text here")
+    RevisionParagraph.from_paragraph(cell_p).add_tracked_deletion(start=0, end=4, author="A", revision_id=2)
+
+    extra_cell_p = table.cell(0, 1).add_paragraph("Second cell ")
+    RevisionParagraph.from_paragraph(extra_cell_p).add_tracked_insertion(text="cell_ins", author="A", revision_id=3)
+
+    # Nested table inside the first cell
+    nested_cell = table.cell(0, 0)
+    nested = nested_cell.add_table(rows=1, cols=1)
+    nested_p = nested.cell(0, 0).paragraphs[0]
+    nested_p.add_run("Nested")
+    RevisionParagraph.from_paragraph(nested_p).add_tracked_insertion(text="nested_ins", author="A", revision_id=4)
+
+    return doc
+
+
+class DescribeTables:
+    """Accept/reject tracked changes inside tables (issue #9)."""
+
+    def it_sees_tracked_changes_inside_tables(self):
+        doc = _build_doc_with_table_changes()
+        rdoc = RevisionDocument(doc)
+
+        # All 4 tracked changes should be visible (body + 2 cells + nested)
+        assert len(rdoc.track_changes) == 4
+
+    def it_all_paragraphs_includes_table_paragraphs(self):
+        doc = _build_doc_with_table_changes()
+        rdoc = RevisionDocument(doc)
+
+        # paragraphs (body-only) is smaller than all_paragraphs
+        assert len(rdoc.paragraphs) < len(rdoc.all_paragraphs)
+        # Body has 1 paragraph; tables contribute at least 3 more
+        assert len(rdoc.all_paragraphs) >= 4
+
+    def it_paragraphs_property_remains_body_only(self):
+        doc = _build_doc_with_table_changes()
+        rdoc = RevisionDocument(doc)
+
+        # Backwards compat: paragraphs returns only body paragraphs
+        assert len(rdoc.paragraphs) == 1
+
+    def it_accepts_all_changes_inside_tables(self):
+        doc = _build_doc_with_table_changes()
+        rdoc = RevisionDocument(doc)
+
+        rdoc.accept_all()
+
+        assert len(rdoc.track_changes) == 0
+        for para in rdoc.all_paragraphs:
+            assert para.has_track_changes is False
+
+    def it_rejects_all_changes_inside_tables(self):
+        doc = _build_doc_with_table_changes()
+        rdoc = RevisionDocument(doc)
+
+        rdoc.reject_all()
+
+        assert len(rdoc.track_changes) == 0
+        for para in rdoc.all_paragraphs:
+            assert para.has_track_changes is False
+
+    def it_accept_all_preserves_insertion_text_in_cell(self):
+        doc = Document()
+        table = doc.add_table(rows=1, cols=1)
+        cell_p = table.cell(0, 0).paragraphs[0]
+        cell_p.add_run("Start ")
+        RevisionParagraph.from_paragraph(cell_p).add_tracked_insertion(text="kept", author="A", revision_id=1)
+
+        rdoc = RevisionDocument(doc)
+        rdoc.accept_all()
+
+        final_text = RevisionParagraph.from_paragraph(rdoc.document.tables[0].cell(0, 0).paragraphs[0]).text
+        assert "kept" in final_text
+
+    def it_reject_all_removes_insertion_in_cell(self):
+        doc = Document()
+        table = doc.add_table(rows=1, cols=1)
+        cell_p = table.cell(0, 0).paragraphs[0]
+        cell_p.add_run("Start ")
+        RevisionParagraph.from_paragraph(cell_p).add_tracked_insertion(text="gone", author="A", revision_id=1)
+
+        rdoc = RevisionDocument(doc)
+        rdoc.reject_all()
+
+        final_text = RevisionParagraph.from_paragraph(rdoc.document.tables[0].cell(0, 0).paragraphs[0]).text
+        assert "gone" not in final_text
+
+    def it_find_and_replace_tracked_works_in_nested_tables(self):
+        doc = Document()
+        doc.add_paragraph("Replace me here")
+        table = doc.add_table(rows=1, cols=1)
+        table.cell(0, 0).paragraphs[0].add_run("Replace me in cell")
+        nested = table.cell(0, 0).add_table(rows=1, cols=1)
+        nested.cell(0, 0).paragraphs[0].add_run("Replace me nested")
+
+        rdoc = RevisionDocument(doc)
+        count = rdoc.find_and_replace_tracked("Replace me", "Done", author="A")
+
+        assert count == 3


### PR DESCRIPTION
## Summary

`accept_all()`, `reject_all()`, and the `track_changes` property walked body paragraphs only, so tracked changes inside table cells were silently skipped.

This PR adds `_iter_all_paragraphs()`, which yields every `RevisionParagraph` in the body and recurses into tables and nested tables via `cell.tables`. `accept_all`, `reject_all`, `track_changes`, and `find_and_replace_tracked` now use it.

A new `all_paragraphs` property exposes the full walk. The original `paragraphs` property stays body-only so README snippets, docs examples, and existing integration tests keep working.

Closes #9

## Test plan

- [x] `uv run pytest tests/ -x` (99 pass)
- [x] New `DescribeTables` in `tests/test_accept_reject.py` covers:
  - tracked changes inside cells are counted
  - `all_paragraphs` includes table paragraphs; `paragraphs` stays body-only
  - `accept_all()` and `reject_all()` clear changes across body, cells, and nested tables
  - insertion text survives accept and disappears on reject inside cells
  - `find_and_replace_tracked` reaches nested tables

Generated with [Claude Code](https://claude.com/claude-code)