### PR TITLE
feat: act on accepted/original text indices (closes #8)

### DIFF
--- a/docx_revisions/document.py
+++ b/docx_revisions/document.py
@@ -13,7 +13,7 @@ from typing import IO, List
 from docx import Document as _new_document
 from docx.document import Document as _DocumentClass
 
-from docx_revisions.paragraph import RevisionParagraph
+from docx_revisions.paragraph import IndexMode, RevisionParagraph
 from docx_revisions.revision import TrackedChange
 
 
@@ -69,23 +69,34 @@ class RevisionDocument:
         """Accept every tracked change in the document.
 
         Insertions are kept (wrapper removed), deletions are removed entirely.
+        Loops until no tracked changes remain so that nested revisions (which
+        can arise from ``replace_tracked(index_mode="accepted")``) are fully
+        resolved.
         """
         for para in self.paragraphs:
-            for change in list(para.track_changes):
-                change.accept()
+            while para.track_changes:
+                for change in list(para.track_changes):
+                    change.accept()
 
     def reject_all(self) -> None:
         """Reject every tracked change in the document.
 
         Insertions are removed entirely, deletions are kept (wrapper removed,
-        ``w:delText`` converted back to ``w:t``).
+        ``w:delText`` converted back to ``w:t``).  Loops until no tracked
+        changes remain.
         """
         for para in self.paragraphs:
-            for change in list(para.track_changes):
-                change.reject()
+            while para.track_changes:
+                for change in list(para.track_changes):
+                    change.reject()
 
     def find_and_replace_tracked(
-        self, search_text: str, replace_text: str, author: str = "", comment: str | None = None
+        self,
+        search_text: str,
+        replace_text: str,
+        author: str = "",
+        comment: str | None = None,
+        index_mode: IndexMode = "text",
     ) -> int:
         """Find and replace across the whole document with track changes.
 
@@ -97,6 +108,9 @@ class RevisionDocument:
             author: Author name for the revisions.
             comment: Optional comment text (requires python-docx comment
                 support).
+            index_mode: Which text view to search against per paragraph.  See
+                :meth:`RevisionParagraph.replace_tracked` — ``"text"`` (default),
+                ``"accepted"``, or ``"original"``.
 
         Returns:
             Total number of replacements made.
@@ -104,24 +118,29 @@ class RevisionDocument:
         Example:
             ```python
             rdoc = RevisionDocument("doc.docx")
+            # Replace against the accepted view so matches inside prior
+            # tracked insertions are also found.
             count = rdoc.find_and_replace_tracked(
-                "Acme Corp", "NewCo Inc", author="Legal"
+                "Acme Corp", "NewCo Inc", author="Legal", index_mode="accepted"
             )
-            print(f"Replaced {count} occurrences")
             rdoc.save("doc_revised.docx")
             ```
         """
         total_count = 0
 
         for para in self.paragraphs:
-            total_count += para.replace_tracked(search_text, replace_text, author=author, comment=comment)
+            total_count += para.replace_tracked(
+                search_text, replace_text, author=author, comment=comment, index_mode=index_mode
+            )
 
         for table in self._document.tables:
             for row in table.rows:
                 for cell in row.cells:
                     for p in cell.paragraphs:
                         rp = RevisionParagraph.from_paragraph(p)
-                        total_count += rp.replace_tracked(search_text, replace_text, author=author, comment=comment)
+                        total_count += rp.replace_tracked(
+                            search_text, replace_text, author=author, comment=comment, index_mode=index_mode
+                        )
 
         return total_count
 

--- a/docx_revisions/paragraph.py
+++ b/docx_revisions/paragraph.py
@@ -8,13 +8,14 @@ and deletions.
 from __future__ import annotations
 
 import datetime as dt
-from typing import TYPE_CHECKING, Iterator, List
+from typing import TYPE_CHECKING, Iterator, List, Literal
 
 from docx.oxml.ns import qn
 from docx.oxml.parser import OxmlElement
 from docx.text.hyperlink import Hyperlink
 from docx.text.paragraph import Paragraph
 from docx.text.run import Run
+from lxml import etree
 
 from docx_revisions._helpers import (
     make_del_element,
@@ -27,6 +28,8 @@ from docx_revisions.revision import TrackedChange, TrackedDeletion, TrackedInser
 
 if TYPE_CHECKING:
     from docx.styles.style import CharacterStyle
+
+IndexMode = Literal["text", "accepted", "original"]
 
 
 class RevisionParagraph(Paragraph):
@@ -108,16 +111,22 @@ class RevisionParagraph(Paragraph):
                 insertions (original/rejected view).
         """
         include_tag = qn("w:ins") if accept_changes else qn("w:del")
-        parts: List[str] = []
-        for element in self._p.xpath("./w:r | ./w:ins | ./w:del"):
-            tag = element.tag  # pyright: ignore[reportUnknownMemberType]
-            if tag == qn("w:r"):
-                run = Run(element, self)
-                parts.append(run.text)
-            elif tag == include_tag:
-                tracked = TrackedInsertion(element, self) if accept_changes else TrackedDeletion(element, self)  # pyright: ignore[reportArgumentType]
-                parts.append(tracked.text)
-        return "".join(parts)
+        skip_tag = qn("w:del") if accept_changes else qn("w:ins")
+
+        def walk(element: etree._Element) -> str:
+            parts: List[str] = []
+            for child in element.xpath("./w:r | ./w:ins | ./w:del"):
+                tag = child.tag
+                if tag == qn("w:r"):
+                    for t in child.xpath("./w:t | ./w:delText"):
+                        parts.append(t.text or "")
+                elif tag == include_tag:
+                    parts.append(walk(child))
+                elif tag == skip_tag:
+                    continue
+            return "".join(parts)
+
+        return walk(self._p)
 
     @property
     def accepted_text(self) -> str:
@@ -225,7 +234,7 @@ class RevisionParagraph(Paragraph):
         return tracked_insertion
 
     def add_tracked_deletion(
-        self, start: int, end: int, author: str = "", revision_id: int | None = None
+        self, start: int, end: int, author: str = "", revision_id: int | None = None, index_mode: IndexMode = "text"
     ) -> TrackedDeletion:
         """Wrap existing text at *[start, end)* in a ``w:del`` element.
 
@@ -238,53 +247,78 @@ class RevisionParagraph(Paragraph):
             author: Author name for the revision.
             revision_id: Unique ID for this revision.  Auto-generated if not
                 provided.
+            index_mode: Which text view the offsets index into:
+                ``"text"`` (default, raw ``paragraph.text`` ignoring prior
+                revisions), ``"accepted"`` (``paragraph.accepted_text``, with
+                prior insertions kept and deletions skipped), or
+                ``"original"`` (``paragraph.original_text``, with prior
+                deletions kept and insertions skipped).
 
         Returns:
             A ``TrackedDeletion`` wrapping the new ``w:del`` element.
 
         Raises:
             ValueError: If offsets are invalid.
+
+        Example:
+            ```python
+            # Delete characters from the accepted (post-revision) view
+            rp.add_tracked_deletion(0, 5, author="Editor", index_mode="accepted")
+            ```
         """
-        para_text = self.text
-        if start < 0 or end > len(para_text) or start >= end:
-            raise ValueError(f"Invalid offsets: start={start}, end={end} for text of length {len(para_text)}")
+        view_text = self._view_text(index_mode)
+        if start < 0 or end > len(view_text) or start >= end:
+            raise ValueError(f"Invalid offsets: start={start}, end={end} for text of length {len(view_text)}")
 
         if revision_id is None:
             revision_id = self._next_revision_id()
 
-        run_boundaries = self._get_run_boundaries()
-        if not run_boundaries:
+        units = self._get_editable_units(index_mode)
+        if not units:
             raise ValueError("Paragraph has no runs")
+        boundaries = self._unit_boundaries(units)
 
-        start_run_idx, start_offset = self._find_run_at_offset(run_boundaries, start)
-        end_run_idx, end_offset = self._find_run_at_offset(run_boundaries, end)
+        start_unit_idx, start_offset = self._find_unit_at_offset(boundaries, start)
+        end_unit_idx, end_offset = self._find_unit_at_offset(boundaries, end)
+
+        # All units in the [start, end) span must share the same parent for a
+        # clean single-parent splice.  This holds when the span is entirely in
+        # top-level w:r runs, or entirely inside one w:ins / w:del wrapper.
+        start_parent = units[start_unit_idx].getparent()
+        end_parent = units[end_unit_idx].getparent()
+        if start_parent is None or start_parent is not end_parent:
+            raise ValueError(
+                "Cannot apply tracked deletion across a revision boundary; "
+                "operate on a narrower span entirely inside or outside a prior revision."
+            )
+        parent = start_parent
 
         now = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        runs = list(self.runs)
+
+        def _r_text(r: etree._Element) -> str:
+            parts = []
+            for child in r.xpath("./w:t | ./w:delText"):
+                parts.append(child.text or "")
+            return "".join(parts)
 
         # Collect the deleted text
         deleted_text_parts: List[str] = []
-        if start_run_idx == end_run_idx:
-            deleted_text_parts.append(runs[start_run_idx].text[start_offset:end_offset])
+        if start_unit_idx == end_unit_idx:
+            deleted_text_parts.append(_r_text(units[start_unit_idx])[start_offset:end_offset])
         else:
-            deleted_text_parts.append(runs[start_run_idx].text[start_offset:])
-            for i in range(start_run_idx + 1, end_run_idx):
-                deleted_text_parts.append(runs[i].text)
-            deleted_text_parts.append(runs[end_run_idx].text[:end_offset])
+            deleted_text_parts.append(_r_text(units[start_unit_idx])[start_offset:])
+            for i in range(start_unit_idx + 1, end_unit_idx):
+                deleted_text_parts.append(_r_text(units[i]))
+            deleted_text_parts.append(_r_text(units[end_unit_idx])[:end_offset])
         deleted_text = "".join(deleted_text_parts)
 
-        # Build the w:del element
-        start_r = runs[start_run_idx]._r
-        parent = start_r.getparent()
-        if parent is None:
-            raise ValueError("Run has no parent element")
-
-        before_text = runs[start_run_idx].text[:start_offset]
-        after_text = runs[end_run_idx].text[end_offset:]
+        start_r = units[start_unit_idx]
+        before_text = _r_text(start_r)[:start_offset]
+        after_text = _r_text(units[end_unit_idx])[end_offset:]
 
         index = list(parent).index(start_r)
-        for i in range(start_run_idx, end_run_idx + 1):
-            run_elem = runs[i]._r
+        for i in range(start_unit_idx, end_unit_idx + 1):
+            run_elem = units[i]
             if run_elem.getparent() is parent:
                 parent.remove(run_elem)
 
@@ -303,7 +337,14 @@ class RevisionParagraph(Paragraph):
 
         return TrackedDeletion(del_elem, self)  # pyright: ignore[reportArgumentType]
 
-    def replace_tracked(self, search_text: str, replace_text: str, author: str = "", comment: str | None = None) -> int:
+    def replace_tracked(
+        self,
+        search_text: str,
+        replace_text: str,
+        author: str = "",
+        comment: str | None = None,
+        index_mode: IndexMode = "text",
+    ) -> int:
         """Replace all occurrences of *search_text* with *replace_text* using track changes.
 
         Each replacement creates a tracked deletion of *search_text* and a
@@ -316,19 +357,29 @@ class RevisionParagraph(Paragraph):
             author: Author name for the revision.
             comment: Optional comment text (requires python-docx comment
                 support).
+            index_mode: Which text view to search against:
+                ``"text"`` (default, raw ``paragraph.text``),
+                ``"accepted"`` (``paragraph.accepted_text``, includes prior
+                insertions, skips prior deletions), or ``"original"``
+                (``paragraph.original_text``, includes prior deletions, skips
+                prior insertions).
 
         Returns:
             The number of replacements made.
 
         Example:
             ```python
-            rp = RevisionParagraph.from_paragraph(paragraph)
-            count = rp.replace_tracked("old", "new", author="Editor")
+            # Default: search raw run text
+            rp.replace_tracked("old", "new", author="Editor")
+
+            # Search the accepted view — matches land inside prior w:ins blocks
+            rp.replace_tracked(
+                "old", "new", author="Editor", index_mode="accepted"
+            )
             ```
         """
         count = 0
-        # Concatenate all run text and search across run boundaries.
-        full_text = self.text
+        full_text = self._view_text(index_mode)
         search_len = len(search_text)
 
         # Find all match positions in the concatenated text.
@@ -344,19 +395,26 @@ class RevisionParagraph(Paragraph):
 
         # Apply replacements right-to-left to preserve offsets.
         for pos in reversed(positions):
-            self.replace_tracked_at(pos, pos + search_len, replace_text, author=author, comment=comment)
+            self.replace_tracked_at(
+                pos, pos + search_len, replace_text, author=author, comment=comment, index_mode=index_mode
+            )
             count += 1
 
         return count
 
     def replace_tracked_at(
-        self, start: int, end: int, replace_text: str, author: str = "", comment: str | None = None
+        self,
+        start: int,
+        end: int,
+        replace_text: str,
+        author: str = "",
+        comment: str | None = None,
+        index_mode: IndexMode = "text",
     ) -> None:
         """Replace text at character offsets *[start, end)* using track changes.
 
         Creates a tracked deletion of the text at positions ``[start, end)``
-        and a tracked insertion of *replace_text* at that position.  The
-        offsets are relative to ``paragraph.text``.
+        and a tracked insertion of *replace_text* at that position.
 
         Args:
             start: Starting character offset (0-based, inclusive).
@@ -365,56 +423,75 @@ class RevisionParagraph(Paragraph):
             author: Author name for the revision.
             comment: Optional comment text (requires python-docx comment
                 support).
+            index_mode: Which text view the offsets index into.  See
+                :meth:`replace_tracked`.
 
         Raises:
             ValueError: If *start* or *end* are out of bounds or *start* >= *end*.
+
+        Example:
+            ```python
+            # Offsets are interpreted against accepted_text
+            rp.replace_tracked_at(
+                0, 5, "Hi", author="Editor", index_mode="accepted"
+            )
+            ```
         """
-        para_text = self.text
-        if start < 0 or end > len(para_text) or start >= end:
-            raise ValueError(f"Invalid offsets: start={start}, end={end} for text of length {len(para_text)}")
+        view_text = self._view_text(index_mode)
+        if start < 0 or end > len(view_text) or start >= end:
+            raise ValueError(f"Invalid offsets: start={start}, end={end} for text of length {len(view_text)}")
 
-        run_boundaries = self._get_run_boundaries()
-        if not run_boundaries:
+        units = self._get_editable_units(index_mode)
+        if not units:
             raise ValueError("Paragraph has no runs")
+        boundaries = self._unit_boundaries(units)
 
-        start_run_idx, start_offset_in_run = self._find_run_at_offset(run_boundaries, start)
-        end_run_idx, end_offset_in_run = self._find_run_at_offset(run_boundaries, end)
+        start_unit_idx, start_offset_in_unit = self._find_unit_at_offset(boundaries, start)
+        end_unit_idx, end_offset_in_unit = self._find_unit_at_offset(boundaries, end)
+
+        start_parent = units[start_unit_idx].getparent()
+        end_parent = units[end_unit_idx].getparent()
+        if start_parent is None or start_parent is not end_parent:
+            raise ValueError(
+                "Cannot apply tracked replacement across a revision boundary; "
+                "operate on a narrower span entirely inside or outside a prior revision."
+            )
+        parent = start_parent
 
         now = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        runs = list(self.runs)
 
-        # Compute the text splits
-        if start_run_idx == end_run_idx:
-            run = runs[start_run_idx]
-            text = run.text
-            before_text = text[:start_offset_in_run] or None
-            deleted_text = text[start_offset_in_run:end_offset_in_run]
-            after_text = text[end_offset_in_run:] or None
-            first_r = run._r
+        def _r_text(r: etree._Element) -> str:
+            parts = []
+            for child in r.xpath("./w:t | ./w:delText"):
+                parts.append(child.text or "")
+            return "".join(parts)
+
+        if start_unit_idx == end_unit_idx:
+            r = units[start_unit_idx]
+            text = _r_text(r)
+            before_text = text[:start_offset_in_unit] or None
+            deleted_text = text[start_offset_in_unit:end_offset_in_unit]
+            after_text = text[end_offset_in_unit:] or None
+            first_r = r
         else:
-            start_run = runs[start_run_idx]
-            start_text = start_run.text
-            before_text = start_text[:start_offset_in_run] or None
-            deleted_from_start = start_text[start_offset_in_run:]
+            first_r = units[start_unit_idx]
+            start_text = _r_text(first_r)
+            before_text = start_text[:start_offset_in_unit] or None
+            deleted_from_start = start_text[start_offset_in_unit:]
 
-            end_run = runs[end_run_idx]
-            end_text = end_run.text
-            deleted_from_end = end_text[:end_offset_in_run]
-            after_text = end_text[end_offset_in_run:] or None
+            end_r = units[end_unit_idx]
+            end_text = _r_text(end_r)
+            deleted_from_end = end_text[:end_offset_in_unit]
+            after_text = end_text[end_offset_in_unit:] or None
 
-            middle_deleted = "".join(runs[i].text for i in range(start_run_idx + 1, end_run_idx))
+            middle_deleted = "".join(_r_text(units[i]) for i in range(start_unit_idx + 1, end_unit_idx))
             deleted_text = deleted_from_start + middle_deleted + deleted_from_end
-            first_r = start_run._r
-
-        parent = first_r.getparent()
-        if parent is None:
-            return
 
         index = list(parent).index(first_r)
 
-        # Remove spanned runs
-        for i in range(start_run_idx, end_run_idx + 1):
-            run_elem = runs[i]._r
+        # Remove spanned runs (only if they share the parent, which the check above guarantees)
+        for i in range(start_unit_idx, end_unit_idx + 1):
+            run_elem = units[i]
             if run_elem.getparent() is parent:
                 parent.remove(run_elem)
 
@@ -430,20 +507,80 @@ class RevisionParagraph(Paragraph):
         """Generate the next unique revision ID for this document."""
         return next_revision_id(self._p)
 
-    def _get_run_boundaries(self) -> List[tuple[int, int, int]]:
-        """Return list of ``(run_index, start_offset, end_offset)`` for each run."""
-        boundaries = []
+    def _view_text(self, index_mode: IndexMode) -> str:
+        """Return the paragraph text for the chosen index mode."""
+        if index_mode == "text":
+            return self.text
+        if index_mode == "accepted":
+            return self.accepted_text
+        if index_mode == "original":
+            return self.original_text
+        raise ValueError(f"Unknown index_mode: {index_mode!r}")
+
+    def _get_editable_units(self, index_mode: IndexMode) -> List[etree._Element]:
+        """Return the ordered list of ``w:r`` elements that make up *index_mode*'s view.
+
+        - ``"text"``: only top-level ``w:r`` children.
+        - ``"accepted"``: walk ``w:r`` children, recurse into ``w:ins``
+          (prior insertions visible), skip ``w:del``.
+        - ``"original"``: walk ``w:r`` children, recurse into ``w:del``
+          (prior deletions visible), skip ``w:ins``.
+        """
+        if index_mode == "text":
+            return list(self._p.xpath("./w:r"))
+
+        if index_mode == "accepted":
+            recurse_tag = qn("w:ins")
+            skip_tag = qn("w:del")
+        elif index_mode == "original":
+            recurse_tag = qn("w:del")
+            skip_tag = qn("w:ins")
+        else:
+            raise ValueError(f"Unknown index_mode: {index_mode!r}")
+
+        units: List[etree._Element] = []
+
+        def walk(element: etree._Element) -> None:
+            for child in element.xpath("./w:r | ./w:ins | ./w:del"):
+                tag = child.tag
+                if tag == qn("w:r"):
+                    units.append(child)
+                elif tag == recurse_tag:
+                    walk(child)
+                elif tag == skip_tag:
+                    continue
+
+        walk(self._p)
+        return units
+
+    @staticmethod
+    def _unit_boundaries(units: List[etree._Element]) -> List[tuple[int, int, int]]:
+        """Return ``(unit_index, start_offset, end_offset)`` for each unit."""
+        boundaries: List[tuple[int, int, int]] = []
         offset = 0
-        for i, run in enumerate(self.runs):
-            run_len = len(run.text)
+        for i, r in enumerate(units):
+            # Sum text from both w:t and w:delText direct children
+            run_len = 0
+            for child in r.xpath("./w:t | ./w:delText"):
+                run_len += len(child.text or "")
             boundaries.append((i, offset, offset + run_len))
             offset += run_len
         return boundaries
 
-    def _find_run_at_offset(self, boundaries: List[tuple[int, int, int]], offset: int) -> tuple[int, int]:
-        """Find which run contains *offset* and the offset within that run."""
-        for run_idx, run_start, run_end in boundaries:
-            if run_start <= offset < run_end or (offset == run_end and run_idx == len(boundaries) - 1):
-                return run_idx, offset - run_start
+    @staticmethod
+    def _find_unit_at_offset(boundaries: List[tuple[int, int, int]], offset: int) -> tuple[int, int]:
+        """Find which unit contains *offset* and the offset within that unit."""
+        for unit_idx, unit_start, unit_end in boundaries:
+            if unit_start <= offset < unit_end or (offset == unit_end and unit_idx == len(boundaries) - 1):
+                return unit_idx, offset - unit_start
         last_idx, last_start, _ = boundaries[-1]
         return last_idx, offset - last_start
+
+    # Back-compat aliases (used by older external code or tests that may import them)
+    def _get_run_boundaries(self) -> List[tuple[int, int, int]]:
+        """Deprecated: use :meth:`_get_editable_units` + :meth:`_unit_boundaries`."""
+        return self._unit_boundaries(self._get_editable_units("text"))
+
+    def _find_run_at_offset(self, boundaries: List[tuple[int, int, int]], offset: int) -> tuple[int, int]:
+        """Deprecated: use :meth:`_find_unit_at_offset`."""
+        return self._find_unit_at_offset(boundaries, offset)

--- a/tests/test_replace.py
+++ b/tests/test_replace.py
@@ -201,3 +201,106 @@ class DescribeRevisionDocument_find_and_replace_tracked:
         count = rdoc.find_and_replace_tracked("zzz", "yyy", author="Bot")
 
         assert count == 0
+
+    def it_supports_accepted_index_mode(self):
+        doc = Document()
+        para = doc.add_paragraph("Before ")
+        rp = RevisionParagraph.from_paragraph(para)
+        # Prior tracked insertion — visible only in accepted_text
+        rp.add_tracked_insertion("Unisys", author="Prior")
+        rdoc = RevisionDocument(doc)
+
+        count = rdoc.find_and_replace_tracked("Unisys", "NewCo", author="Bot", index_mode="accepted")
+
+        assert count == 1
+
+
+class DescribeRevisionParagraph_accepted_index_mode:
+    """Tests for index_mode='accepted' on replace / delete methods."""
+
+    def _para_with_prior_insertion(self):
+        doc = Document()
+        para = doc.add_paragraph("Hello ")  # "Hello " in a w:r
+        rp = RevisionParagraph.from_paragraph(para)
+        rp.add_tracked_insertion("Unisys World", author="Prior")  # inside w:ins
+        return rp
+
+    def _para_with_prior_deletion(self):
+        doc = Document()
+        para = doc.add_paragraph("Hello DELETED World")
+        rp = RevisionParagraph.from_paragraph(para)
+        # Mark "DELETED " as a tracked deletion (offsets into raw text)
+        rp.add_tracked_deletion(start=6, end=14, author="Prior")
+        return rp
+
+    def it_finds_text_inside_prior_insertion_with_accepted_mode(self):
+        rp = self._para_with_prior_insertion()
+        # accepted_text == "Hello Unisys World"; raw self.text == "Hello "
+        count = rp.replace_tracked("Unisys", "NewCo", author="Bot", index_mode="accepted")
+
+        assert count == 1
+        # New w:del/w:ins are nested inside the prior w:ins — search descendants.
+        del_texts = ["".join(t.text or "" for t in d.xpath(".//w:delText")) for d in rp._p.xpath(".//w:del")]
+        ins_texts = ["".join(t.text or "" for t in i.xpath("./w:r/w:t")) for i in rp._p.xpath(".//w:ins")]
+        assert "Unisys" in del_texts
+        assert "NewCo" in ins_texts
+        # Round-trip: accepted view should now read "Hello NewCo World"
+        assert rp.accepted_text == "Hello NewCo World"
+
+    def it_default_mode_cannot_find_text_inside_prior_insertion(self):
+        rp = self._para_with_prior_insertion()
+        count = rp.replace_tracked("Unisys", "NewCo", author="Bot")
+        assert count == 0
+
+    def it_offsets_skip_deleted_content_in_accepted_mode(self):
+        rp = self._para_with_prior_deletion()
+        # accepted_text == "Hello World" (the deletion is hidden)
+        assert rp.accepted_text == "Hello World"
+        # Replace "World" at accepted offsets [6, 11)
+        rp.replace_tracked_at(start=6, end=11, replace_text="Earth", author="Bot", index_mode="accepted")
+
+        assert any(d.text == "World" for d in rp.deletions)
+        assert any(i.text == "Earth" for i in rp.insertions)
+
+    def it_original_mode_sees_deleted_but_not_inserted(self):
+        doc = Document()
+        para = doc.add_paragraph("Keep DEL ")
+        rp = RevisionParagraph.from_paragraph(para)
+        rp.add_tracked_deletion(start=5, end=8, author="Prior")  # "DEL"
+        rp.add_tracked_insertion("INS", author="Prior")
+
+        # original_text includes "DEL" (kept) but excludes "INS" (skipped)
+        assert "DEL" in rp.original_text
+        assert "INS" not in rp.original_text
+        # accepted_text excludes "DEL" but includes "INS"
+        assert "DEL" not in rp.accepted_text
+        assert "INS" in rp.accepted_text
+
+    def it_add_tracked_deletion_with_accepted_mode(self):
+        rp = self._para_with_prior_insertion()
+        # accepted_text == "Hello Unisys World" — delete "Unisys" (6..12)
+        rp.add_tracked_deletion(start=6, end=12, author="Bot", index_mode="accepted")
+
+        # The deletion should now exist somewhere (nested inside the w:ins)
+        # and rendering accepted_text should no longer contain "Unisys"
+        assert "Unisys" not in rp.accepted_text
+
+    def it_round_trips_through_accept_all(self):
+        rp = self._para_with_prior_insertion()
+        doc = rp._parent._parent  # underlying python-docx document
+        rdoc = RevisionDocument(doc)
+        rdoc.find_and_replace_tracked("Unisys", "NewCo", author="Bot", index_mode="accepted")
+        rdoc.accept_all()
+
+        assert rdoc.paragraphs[0].text == "Hello NewCo World"
+
+    def it_default_mode_behaves_unchanged_for_plain_paragraph(self):
+        doc = Document()
+        para = doc.add_paragraph("Hello World")
+        rp = RevisionParagraph.from_paragraph(para)
+
+        count = rp.replace_tracked("World", "Earth", author="Bot")
+
+        assert count == 1
+        assert any(d.text == "World" for d in rp.deletions)
+        assert any(i.text == "Earth" for i in rp.insertions)


### PR DESCRIPTION
## Summary
- Adds an opt-in `index_mode: Literal["text", "accepted", "original"] = "text"` parameter to `replace_tracked`, `replace_tracked_at`, `add_tracked_deletion`, and `RevisionDocument.find_and_replace_tracked`.
- `"accepted"` treats offsets / search as if operating on `paragraph.accepted_text` — matches can land inside prior `w:ins` blocks and skip over prior `w:del` content (mimics a word-processor editing flow).
- `"original"` is the symmetric view operating on `paragraph.original_text`.
- Default remains `"text"` so existing callers are fully back-compat.
- When an operation lands inside a prior `w:ins`, the new `w:del` / `w:ins` are spliced into the same parent (nested inside that `w:ins`), preserving the existing revision structure.
- `accept_all` / `reject_all` now loop until no tracked changes remain so nested revisions created by accepted-mode edits are fully resolved in a single call.

Closes #8

## Test plan
- [x] Existing 91 tests still pass (behavior unchanged with default mode).
- [x] New tests cover:
  - replace_tracked with `index_mode="accepted"` finds text inside prior `w:ins`.
  - Default mode does NOT match text inside prior `w:ins` (baseline).
  - replace_tracked_at with `index_mode="accepted"` correctly offsets past prior `w:del` content.
  - `original_text` / `accepted_text` correctness check.
  - add_tracked_deletion with `index_mode="accepted"` inside a prior `w:ins`.
  - find_and_replace_tracked on `RevisionDocument` with `index_mode="accepted"`.
  - Round-trip: accepted-mode replace -> accept_all -> final `text` is correct.
- [x] `uv run pytest tests/ -x` passes (99 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)